### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/net.sourceforge.VMPK.json
+++ b/net.sourceforge.VMPK.json
@@ -1,7 +1,7 @@
 {
   "app-id": "net.sourceforge.VMPK",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15",
+  "runtime-version": "5.15-21.08",
   "sdk": "org.kde.Sdk",
   "command": "vmpk",
   "rename-icon": "vmpk",


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.