### PR TITLE
Update runtime to 6.2

### DIFF
--- a/net.sourceforge.VMPK.json
+++ b/net.sourceforge.VMPK.json
@@ -1,7 +1,7 @@
 {
   "app-id": "net.sourceforge.VMPK",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15-21.08",
+  "runtime-version": "6.2",
   "sdk": "org.kde.Sdk",
   "command": "vmpk",
   "rename-icon": "vmpk",

--- a/net.sourceforge.VMPK.json
+++ b/net.sourceforge.VMPK.json
@@ -32,6 +32,10 @@
       "name": "drumstick",
       "buildsystem": "cmake-ninja",
       "config-opts": [
+        "-DBUILD_ALSA=ON",
+        "-DBUILD_FILE=OFF",
+        "-DBUILD_RT=ON",
+        "-DBUILD_WIDGETS=ON",
         "-DBUILD_DOCS=OFF",
         "-DBUILD_UTILS=OFF",
         "-DBUILD_TESTING=OFF"
@@ -50,8 +54,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://downloads.sourceforge.net/project/drumstick/2.4.1/drumstick-2.4.1.tar.bz2",
-          "sha256": "9e6aa04b4f19050daf0440eda2b88d6d82da3500350d678385b468ef4ac138fd"
+          "url": "https://downloads.sourceforge.net/project/drumstick/2.5.0/drumstick-2.5.0.tar.bz2",
+          "sha256": "8709d8a7c438c1d09091827ce5fd8286d387a046a8f717a1a34546d9ca3d902a"
         }
       ]
     },
@@ -59,14 +63,11 @@
       "name": "vmpk",
       "buildsystem": "cmake-ninja",
       "config-opts": [ "-DBUILD_DOCS=OFF" ],
-      "post-install": [
-        "install -Dm644 -t /app/share/metainfo/ net.sourceforge.VMPK.appdata.xml"
-      ],
       "sources": [
         {
           "type": "archive",
-          "url": "http://downloads.sourceforge.net/project/vmpk/vmpk/0.8.5/vmpk-0.8.5.tar.bz2",
-          "sha256": "48fa267b850a18e5902d3f51328199d3051dc28746f264886861428348b90a66"
+          "url": "http://downloads.sourceforge.net/project/vmpk/vmpk/0.8.6/vmpk-0.8.6.tar.bz2",
+          "sha256": "7307c9255794a24c99235886bea06f5e3701477e951a8773ad4c7902dbf73ce3"
         }
       ]
     }


### PR DESCRIPTION
This is the KDE Runtime with Qt 6.2 but no KDE libraries for now.

Let's try this one and see if it works. This is a bigger change than https://github.com/flathub/net.sourceforge.VMPK/pull/9 thus careful testing might be needed.